### PR TITLE
insert an interactive question

### DIFF
--- a/usr/local/bin/changesink
+++ b/usr/local/bin/changesink
@@ -6,9 +6,11 @@
 pkill autostream
 
 # Edit this line to whatever Sink Index You prefer
-# Default Sink Output
-SINKOUTPUT=$1
-
+echo 'Here is a list of outputs detected on your system.  
+echo 'Please enter which output you want?'
+echo 'For Example: Type "1" if the desired output for your Chromecast Audio device is on sink #1'
+pactl list short sinks
+read SINKOUTPUT
 
 
 

--- a/usr/local/bin/changesink
+++ b/usr/local/bin/changesink
@@ -5,13 +5,16 @@
 # $ changesink 3      #changes the active sink to Sink #3
 pkill autostream
 
-# Edit this line to whatever Sink Index You prefer
-echo 'Here is a list of outputs detected on your system.  
-echo 'Please enter which output you want?'
-echo 'For Example: Type "1" if the desired output for your Chromecast Audio device is on sink #1'
-pactl list short sinks
-read SINKOUTPUT
-
+# Check if a value has been passed on from server.js, if not, then ask for a value to be given manually
+if [ $1 -eq 0 ] ; then
+    SINKOUTPUT=$1
+else
+    echo 'Here is a list of outputs detected on your system.  
+    echo 'Please enter which output you want?'
+    echo 'For Example: Type "1" if the desired output for your Chromecast Audio device is on sink #1'
+    pactl list short sinks
+    read SINKOUTPUT
+fi
 
 
 pactl list short sink-inputs|while read stream; do

--- a/usr/local/bin/changesink
+++ b/usr/local/bin/changesink
@@ -5,15 +5,15 @@
 # $ changesink 3      #changes the active sink to Sink #3
 pkill autostream
 
-# Check if a value has been passed on from server.js, if not, then ask for a value to be given manually
-if [ $1 -eq 0 ] ; then
-    SINKOUTPUT=$1
-else
+# Check if a value has been passed on from server.js.  If it has not, then ask for a value to be given manually.  
+if [ -z ${1+x} ]; then
     echo 'Here is a list of outputs detected on your system.  
     echo 'Please enter which output you want?'
     echo 'For Example: Type "1" if the desired output for your Chromecast Audio device is on sink #1'
     pactl list short sinks
     read SINKOUTPUT
+else
+    SINKOUTPUT=$1
 fi
 
 


### PR DESCRIPTION
In an effort to make it easier when running in a command, a user simply has to invoke the 'changesink' command, which will automaticaly show the sinks/choices detected on the system.